### PR TITLE
fix: node bump and add corepack

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,8 +7,11 @@ tasks:
       # Cleanup terminal
       printf "\033[3J\033c\033[3J"
 
-      nvm install 18.16.0
-      nvm use 18.16.0
+      nvm install 20.15.1
+      nvm use 20.15.1
+
+      corepack enable
+      COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack yarn
 
       # Auto init a redwoodjs project for Gitpod if missing
       if test ! -e redwood.toml; then {
@@ -17,6 +20,8 @@ tasks:
 
         # Change the default `sqlite` datasource provider to `postgres`
         sed -i 's|provider = "sqlite"|provider = "postgres"|' "api/db/schema.prisma"
+     
+        yarn install
       } else {
         yarn install
       } fi


### PR DESCRIPTION
**Problem**
The `create redwood-app` step was breaking because we no longer allow node 18. 

**Changes**
1. Bumps node to the current LTS 20.15.1
2. Adds corepack usage

**Notes**
I couldn't push to @pantheredeye's #2 to update it and get it in so credit to him for his existing PR which did the same thing! 