### PR TITLE
fix: prevent duplicate yarn install

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,8 +20,6 @@ tasks:
 
         # Change the default `sqlite` datasource provider to `postgres`
         sed -i 's|provider = "sqlite"|provider = "postgres"|' "api/db/schema.prisma"
-     
-        yarn install
       } else {
         COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack yarn install
       } fi


### PR DESCRIPTION
Now that we use yarn at the latest stable and not v1 then the `--yes` flag will install node_modules and so we don't need the additional call within the if block.